### PR TITLE
fixed schema to accept objects as items in the static pragma

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Architect Parser accepts plaintext, JSON, or YAML .arc manifests and returns a plain JavaScript Object",
   "main": "./src/index.js",
   "scripts": {
-    "deno:test":"deno test -A --unstable mod.test.ts",
+    "deno:test": "deno test -A --unstable mod.test.ts",
     "deno:fmt": "deno fmt mod.ts && deno fmt mod.test.ts",
     "lint": "npx eslint . --fix",
     "test:unit": "tape test/**/*-test.js | tap-spec",

--- a/schema.json
+++ b/schema.json
@@ -135,13 +135,10 @@
       "title": "@static",
       "description": "Static asset & S3 configuration",
       "uniqueItems": true,
-      "type": [
-        "array",
-        "object"
-      ],
+      "type": "array",
       "maxItems": 6,
       "items": {
-        "type": "array",
+        "type": ["array", "object"],
         "items": [
           {
             "type": "string",
@@ -162,24 +159,24 @@
               "object"
             ]
           }
-        ]
-      },
-      "properties": {
-        "folder": {
-          "type": "string"
-        },
-        "fingerprint": {
-          "type": "boolean"
-        },
-        "ignore": {
-          "type": [
-            "string",
-            "object",
-            "array"
-          ]
-        },
-        "spa": {
-          "type": "boolean"
+        ],
+        "properties": {
+          "folder": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "boolean"
+          },
+          "ignore": {
+            "type": [
+              "string",
+              "object",
+              "array"
+            ]
+          },
+          "spa": {
+            "type": "boolean"
+          }
         }
       }
     },

--- a/test/13-validate-test.js
+++ b/test/13-validate-test.js
@@ -17,3 +17,9 @@ test('validation with good JSON schema', t=> {
   console.log(JSON.stringify(output, null, 2))
   console.log(parse(parse.stringify(output.arc)))
 })
+
+test('validation with correct JSON schema including @static with "ignore" setting', t=> {
+  t.plan(1)
+  let output = parse.read({cwd: path.join(__dirname, 'mock', 'good', 'static-ignore')})
+  t.ok(output.errors === false, 'parsed with no errors')
+})

--- a/test/mock/good/static-ignore/.arc
+++ b/test/mock/good/static-ignore/.arc
@@ -1,0 +1,8 @@
+@app
+init
+
+@static
+ignore
+  .tar.gz
+  tmp
+  user


### PR DESCRIPTION
This PR adjusts the schema slightly for validating `@static` settings such as `ignore`, which are maps/objects, and moves validation of those within the `@static` array's items within the schema, rather than validating that the top-level `@static` property be a map/object.

The test that I added fails on master but passes in this PR.

This PR fixes https://github.com/architect/architect/issues/829