### PR TITLE
Add i18n support for non-ascii string chars, fix missing tilde from supported string chars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 ---
 
+## [3.0.1] 2020-12-02
+
+### Added
+
+- Added i18n support for non-ascii string chars
+
+
+### Fixed
+
+- Fixed missing tilde from supported string chars
+
+---
+
 ## [3.0.0] 2020-11-20
 
 ### Added

--- a/src/lexer/regexp.js
+++ b/src/lexer/regexp.js
@@ -54,7 +54,7 @@ const RESERVED = /\{|\}|\[|\]|\<|\>/
  * - single quote '
  * - double quote " is greedy, supports newlines and must have a closing "
  */
-const STRING = /(\()|(\))|(\/)|([a-zA-Z0-9])|(-)|(\_)|(\.)|(\,)|(\:)|(\$)|(\*)|(\?)|(\&)|(\!)|(\%)|(\=)|(\+)|(\|)|(\^)|(\`)|(\')|(\")/
+const STRING = /(\()|(\))|(\/)|(\w)|(\~)|(-)|(\_)|(\.)|(\,)|(\:)|(\$)|(\*)|(\?)|(\&)|(\!)|(\%)|(\=)|(\+)|(\|)|(\^)|(\`)|(\')|(\")/
 
 /**
  * numbers (integer or float; negative modifier supported)


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
