### PR TITLE
Quoted strings in arrays

### DIFF
--- a/src/compiler/arc.js
+++ b/src/compiler/arc.js
@@ -23,12 +23,12 @@ module.exports = function arc (ast) {
           }
           for (let node of token.values) {
             if (node.value) {
-              arc += node.value
+              arc += node.raw ? node.raw : node.value
             }
             if (node.values) {
               arc += node.raw
               for (let key of node.values) {
-                arc += key.value
+                arc += key.raw ? key.raw : key.value
               }
             }
           }

--- a/src/compiler/js.js
+++ b/src/compiler/js.js
@@ -25,13 +25,13 @@ module.exports = function js (ast) {
 
       // array
       if (token.type === 'array') {
-        arc[pragma.name].push(token.values.filter(isScalar).map(t => t.value))
+        arc[pragma.name].push(token.values.filter(isScalar).map(t => t.raw ? t.raw : t.value))
       }
 
       // vector
       if (token.type === 'vector') {
         let vector = {}
-        vector[token.name] = token.values.filter(isScalar).map(t => t.value)
+        vector[token.name] = token.values.filter(isScalar).map(t => t.raw ? t.raw : t.value)
         arc[pragma.name].push(vector)
       }
 

--- a/src/compiler/yaml.js
+++ b/src/compiler/yaml.js
@@ -20,7 +20,7 @@ module.exports = function yaml (ast) {
           arc += '- ' + token.value
         }
         if (token.type === 'array') {
-          arc += '- [ ' + token.values.filter(isScalar).map(t => t.value).join(', ') + ' ]\n'
+          arc += '- [ ' + token.values.filter(isScalar).map(t => t.raw ? t.raw : t.value).join(', ') + ' ]\n'
         }
         if (token.type === 'vector') {
           arc += '- ' + token.raw

--- a/test/04-compiler-test.js
+++ b/test/04-compiler-test.js
@@ -29,6 +29,56 @@ one 2 true`
   console.log(arc)
 })
 
+test('can compile array values with quotes (js)', t => {
+  t.plan(1)
+  let arcfile = `
+@bundles
+my-package node_modules/my-package
+store 'node_modules/@enhance/store'
+ssr "node_modules/@enhance/ssr"`
+  let tokens = parse.lexer(arcfile)
+  let ast = parse.parser(tokens)
+  let arc = parse.compiler(ast)
+  t.same(arc, { bundles: [
+    [ 'my-package', 'node_modules/my-package' ],
+    [ 'store', `'node_modules/@enhance/store'` ],
+    [ 'ssr', `"node_modules/@enhance/ssr"` ]
+  ] })
+  console.log(arc)
+})
+
+test('can compile array values with quotes (arc)', t => {
+  t.plan(3)
+  let arcfile = `
+@bundles
+my-package node_modules/my-package
+store 'node_modules/@enhance/store'
+ssr "node_modules/@enhance/ssr"`
+  let tokens = parse.lexer(arcfile)
+  let ast = parse.parser(tokens)
+  let arc = parse.compiler(ast, 'arc')
+  t.ok(arc.includes(`my-package node_modules/my-package`))
+  t.ok(arc.includes(`store 'node_modules/@enhance/store'`))
+  t.ok(arc.includes(`ssr "node_modules/@enhance/ssr"`))
+  console.log(arc)
+})
+
+test('can compile array values with quotes (yaml)', t => {
+  t.plan(3)
+  let arcfile = `
+@bundles
+my-package node_modules/my-package
+store 'node_modules/@enhance/store'
+ssr "node_modules/@enhance/ssr"`
+  let tokens = parse.lexer(arcfile)
+  let ast = parse.parser(tokens)
+  let arc = parse.compiler(ast, 'yaml')
+  t.ok(arc.includes(`my-package, node_modules/my-package`))
+  t.ok(arc.includes(`store, 'node_modules/@enhance/store'`))
+  t.ok(arc.includes(`ssr, "node_modules/@enhance/ssr"`))
+  console.log(arc)
+})
+
 test('can compile scalar and array values', t => {
   t.plan(1)
   let arcfile = `


### PR DESCRIPTION
When we need to quote a string in an array value like:

```
@bundles
store 'node_modules/@enhance/store'
```

The compiler will output a string that no longer contains the single quotes (or double quotes). Then when you attempt to parse the arc file it will fail due to the `@` character.

Related issue https://github.com/beginner-corp/cli/issues/72

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Signed-off-by: macdonst <simon.macdonald@gmail.com>
