### PR TITLE
adding quote context to AST

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test:unit": "cross-env tape 'test/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "test": "npm run lint && npm run coverage",
-    "test:one": "npm run lint && node test/04-compiler-test.js | tap-spec",
     "rc": "npm version prerelease --preid RC",
     "build": "rollup -c",
     "vendor:js-yaml": "mkdir -p tmp && browserify --node --standalone js-yaml --im --no-builtins node_modules/js-yaml/index.js > tmp/js-yaml.js && terser tmp/js-yaml.js -o src/compat/vendor/js-yaml.min.js",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:unit": "cross-env tape 'test/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "test": "npm run lint && npm run coverage",
+    "test:one": "npm run lint && node test/04-compiler-test.js | tap-spec",
     "rc": "npm version prerelease --preid RC",
     "build": "rollup -c",
     "vendor:js-yaml": "mkdir -p tmp && browserify --node --standalone js-yaml --im --no-builtins node_modules/js-yaml/index.js > tmp/js-yaml.js && terser tmp/js-yaml.js -o src/compat/vendor/js-yaml.min.js",

--- a/src/compiler/arc.js
+++ b/src/compiler/arc.js
@@ -23,12 +23,12 @@ module.exports = function arc (ast) {
           }
           for (let node of token.values) {
             if (node.value) {
-              arc += node.raw ? node.raw : node.value
+              arc += node.quote ? node.raw : node.value
             }
             if (node.values) {
               arc += node.raw
               for (let key of node.values) {
-                arc += key.raw ? key.raw : key.value
+                arc += key.quote ? key.raw : key.value
               }
             }
           }

--- a/src/compiler/js.js
+++ b/src/compiler/js.js
@@ -25,13 +25,13 @@ module.exports = function js (ast) {
 
       // array
       if (token.type === 'array') {
-        arc[pragma.name].push(token.values.filter(isScalar).map(t => t.raw ? t.raw : t.value))
+        arc[pragma.name].push(token.values.filter(isScalar).map(t => t.value))
       }
 
       // vector
       if (token.type === 'vector') {
         let vector = {}
-        vector[token.name] = token.values.filter(isScalar).map(t => t.raw ? t.raw : t.value)
+        vector[token.name] = token.values.filter(isScalar).map(t => t.value)
         arc[pragma.name].push(vector)
       }
 

--- a/src/compiler/yaml.js
+++ b/src/compiler/yaml.js
@@ -20,7 +20,7 @@ module.exports = function yaml (ast) {
           arc += '- ' + token.value
         }
         if (token.type === 'array') {
-          arc += '- [ ' + token.values.filter(isScalar).map(t => t.raw ? t.raw : t.value).join(', ') + ' ]\n'
+          arc += '- [ ' + token.values.filter(isScalar).map(t => t.quote ? t.raw : t.value).join(', ') + ' ]\n'
         }
         if (token.type === 'vector') {
           arc += '- ' + token.raw

--- a/src/lexer/index.js
+++ b/src/lexer/index.js
@@ -143,9 +143,10 @@ module.exports = function lex (code) {
 
     if (STRING.test(code[cursor])) {
       let token = peek.string(cursor, code, line, column)
-      let singleQuote = code[cursor] === "'"
-      let doubleQuote = code[cursor] === '"'
-      let backtick = code[cursor] === '`'
+      let quoteValue = code[cursor]
+      let singleQuote = quoteValue === "'"
+      let doubleQuote =  quoteValue === '"'
+      let backtick = quoteValue === '`'
       let value = {
         type: 'string',
         value: token,
@@ -154,10 +155,8 @@ module.exports = function lex (code) {
       }
       let quote = singleQuote || doubleQuote || backtick
       if (quote) {
-        value.raw = `${code[cursor]}${token}${code[cursor]}`
-        value.singleQuote = singleQuote
-        value.doubleQuote = doubleQuote
-        value.backtick = backtick
+        value.raw = `${quoteValue}${token}${quoteValue}`
+        value.quote = quoteValue
       }
       tokens.push(value)
       cursor += token.length + (quote ? 2 : 0)

--- a/src/lexer/index.js
+++ b/src/lexer/index.js
@@ -143,15 +143,21 @@ module.exports = function lex (code) {
 
     if (STRING.test(code[cursor])) {
       let token = peek.string(cursor, code, line, column)
-      let quote = code[cursor] === '"' || code[cursor] === '`' || code[cursor] === "'"
+      let singleQuote = code[cursor] === "'"
+      let doubleQuote = code[cursor] === '"'
+      let backtick = code[cursor] === '`'
       let value = {
         type: 'string',
         value: token,
         line,
         column
       }
+      let quote = singleQuote || doubleQuote || backtick
       if (quote) {
         value.raw = `${code[cursor]}${token}${code[cursor]}`
+        value.singleQuote = singleQuote
+        value.doubleQuote = doubleQuote
+        value.backtick = backtick
       }
       tokens.push(value)
       cursor += token.length + (quote ? 2 : 0)

--- a/test/04-compiler-test.js
+++ b/test/04-compiler-test.js
@@ -41,8 +41,8 @@ ssr "node_modules/@enhance/ssr"`
   let arc = parse.compiler(ast)
   t.same(arc, { bundles: [
     [ 'my-package', 'node_modules/my-package' ],
-    [ 'store', `'node_modules/@enhance/store'` ],
-    [ 'ssr', `"node_modules/@enhance/ssr"` ]
+    [ 'store', `node_modules/@enhance/store` ],
+    [ 'ssr', `node_modules/@enhance/ssr` ]
   ] })
   console.log(arc)
 })
@@ -286,4 +286,22 @@ hi:
   let ast = parse.parser(tokens)
   let arc = parse.compiler(ast, 'yaml')
   t.same(arc, expected)
+})
+
+test('js compilation strips escape quotes', t => {
+  t.plan(3)
+  let arcfile = `@bundles
+mux-player 'node_modules/@mux/mux-player'
+docsearch-js "node_modules/@docsearch/js"
+docsearch-css \`node_modules/@docsearch/css/dist/style.css\``
+  let tokens = parse.lexer(arcfile)
+  let ast = parse.parser(tokens)
+  let js = parse.compiler(ast, 'js')
+  let first = js.bundles[0][1]
+  let second = js.bundles[1][1]
+  let third = js.bundles[2][1]
+  t.ok(first.startsWith("'") === false)
+  t.ok(second.startsWith('"') === false)
+  t.ok(third.startsWith('`') === false)
+  console.dir([ first, second, third ], { depth: null })
 })

--- a/test/04-compiler-test.js
+++ b/test/04-compiler-test.js
@@ -41,8 +41,8 @@ ssr "node_modules/@enhance/ssr"`
   let arc = parse.compiler(ast)
   t.same(arc, { bundles: [
     [ 'my-package', 'node_modules/my-package' ],
-    [ 'store', `node_modules/@enhance/store` ],
-    [ 'ssr', `node_modules/@enhance/ssr` ]
+    [ 'store', 'node_modules/@enhance/store' ],
+    [ 'ssr', 'node_modules/@enhance/ssr' ]
   ] })
   console.log(arc)
 })
@@ -300,8 +300,8 @@ docsearch-css \`node_modules/@docsearch/css/dist/style.css\``
   let first = js.bundles[0][1]
   let second = js.bundles[1][1]
   let third = js.bundles[2][1]
-  t.ok(first.startsWith("'") === false)
-  t.ok(second.startsWith('"') === false)
-  t.ok(third.startsWith('`') === false)
+  t.ok(first.includes("'") === false)
+  t.ok(second.includes('"') === false)
+  t.ok(third.includes('`') === false)
   console.dir([ first, second, third ], { depth: null })
 })

--- a/test/05-parser-test.js
+++ b/test/05-parser-test.js
@@ -135,3 +135,13 @@ cats
       `
   t.doesNotThrow(run, 'Did not throw')
 })
+
+test('AST quote information is retained', t => {
+  t.plan(1)
+  let arcfile = `@hi\n"there"`
+  let tokens = lex(arcfile)
+  let ast = parse(tokens)
+  let str = ast.values[0].values.find(v => v.type === 'string' && v.quote && v.quote === '"')
+  t.ok(str, 'found the quote on a string value')
+  console.dir(str, { depth: null })
+})


### PR DESCRIPTION
This PR changes parsing/compilation to better support escape quoted strings. The native arc file format supports backtick, single, and double quotes. Compiling to JS should be lossy (the quotes are gone) which was the original behavior. Compiling to arc should not be lossy so parsing/changing a native arc file can retain userland choices about escaping. 