### PR TITLE
docs: fix link to arc file schema in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Architect looks in the following places for the primary definition/configuration
 
 - `.arc`
 - `app.arc` - [example](/examples/arc.arc)
-- `arc.json` - [example](/examples/arc.json) - [schema](https://arc.codes/schema.json)
+- `arc.json` - [example](/examples/arc.json) - [schema](https://github.com/architect/syntaxes)
 - `arc.yaml` - [example](/examples/arc.yml)
 
 > The `.arc` format is unique to Architect with many readability advantages; but is *not required*


### PR DESCRIPTION
This came up in architect/architect#1496