### PR TITLE
test: nested semicolons fail lexing

### DIFF
--- a/test/00-lexer-test.js
+++ b/test/00-lexer-test.js
@@ -14,6 +14,10 @@ false false false
 
 # comment with spaces
 foo bar
+
+thing
+  nested thing
+  semi;colons
 `
 
 test('lex', t => {


### PR DESCRIPTION
This one is a weird, but I'm also alarmed `npm run test:unit` exits with a 0 code even though the test fails. `npx tape test/00-lexer-test.js` correctly exits with a non-zero code. Perhaps `tap-arc` is swallowing up the errors when piped to?

In any case this demonstrates an issue with the parser semi-colons are present (or, in the case of https://github.com/architect/architect/issues/1430, preferences.arc files).